### PR TITLE
Add GitHub URL to Expector dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,9 @@ dependencies = [
 [[package]]
 name = "expector"
 version = "0.1.0"
+dependencies = [
+ "descriptor 0.1.0-pre",
+]
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Sam Phippen <samphippen@googlemail.com>"]
 lazy_static = "0.1.15"
 
 [dev-dependencies]
-expector = { path = "../expector" }
+expector = { git = "https://github.com/samphippen/expector" }


### PR DESCRIPTION
I might be misunderstanding the intention here, so feel free to close these 2 PRs if they don't make sense, but currently both `descriptor` and `expector` are trying to find each other somewhere in the local filesystem. This means that in order to use either one, you would need to have both cloned. My thinking is that if it makes sense to have `descriptor` and `expector` in separate repos, then it also presumably makes sense to have one work without the other being cloned. Let me know what you think.

Counterpart of https://github.com/samphippen/expector/pull/4
